### PR TITLE
remove invalid argument for package kit

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -38,7 +38,7 @@ fi
 if [[ -x /usr/libexec/pk-command-not-found ]]; then
   command_not_found_handler() {
     if [[ -S /var/run/dbus/system_bus_socket && -x /usr/libexec/packagekitd ]]; then
-      /usr/libexec/pk-command-not-found -- "$@"
+      /usr/libexec/pk-command-not-found "$@"
       return $?
     fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removes `--` argument to PackageKit command-not-found that was inadvertently added

## Other comments:
`pk-command-not-found` doesn't accept `--` as an argument. This is what happens when `--` is the first argument:
```
foo@bar ~  gem 
zsh: --: command not found...
```
...
